### PR TITLE
Translate well-known bind mounts to labels

### DIFF
--- a/test/all.spec.ts
+++ b/test/all.spec.ts
@@ -89,6 +89,7 @@ describe('normalization', () => {
 				image: { context: './s2', network: 'none', target: 'stage1' },
 			},
 			{ serviceName: 's3', image: 'some/image' },
+			{ serviceName: 's4', image: 'some/image' },
 		]);
 		done();
 	});
@@ -155,6 +156,20 @@ describe('normalization', () => {
 		expect(c.services.s2.volumes).to.deep.equal(['v2:/v2:ro']);
 		expect(c.services.s3.volumes).to.deep.equal(['v1:/v1']);
 		expect(c.services.s3.tmpfs).to.deep.equal(['/tmp1', '/tmp2']);
+		done();
+	});
+
+	it('should normalize well-known bind mounts to labels', (done) => {
+		expect(c.services.s4.volumes).to.deep.equal([]);
+		expect(c.services.s4.labels).to.deep.equal({
+			'io.balena.features.balena-socket': 1,
+			'io.balena.features.dbus': 1,
+			'io.balena.features.sysfs': 1,
+			'io.balena.features.procfs': 1,
+			'io.balena.features.kernel-modules': 1,
+			'io.balena.features.firmware': 1,
+			'io.balena.features.journal-logs': 1,
+		});
 		done();
 	});
 });

--- a/test/fixtures/default.json
+++ b/test/fixtures/default.json
@@ -74,6 +74,20 @@
           "target": "/tmp2"
         }
       ]
+    },
+    "s4": {
+      "image": "some/image",
+      "volumes": [
+        "/var/run/docker.sock:/host/run/docker.sock",
+        "/run/dbus:/host/run/dbus",
+        "/sys:/sys",
+        "/proc:/proc",
+        "/lib/modules:/lib/modules",
+        "/lib/firmware:/lib/firmware",
+        "/var/log/journal:/var/log/journal",
+        "/run/log/journal:/run/log/journal",
+        "/etc/machine-id:/etc/machine-id"
+      ]
     }
   }
 }


### PR DESCRIPTION
Add support for translating a few bind mounts into labels.

The idea is to allow the same composition containing bind mounts to build with balena-cli (e.g. [open-balena](https://github.com/balena-io/open-balena/pull/141/commits/0d22f5baecc4f5f9248e05cdabe2ac708a114877#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R244)) as well as docker-compose.